### PR TITLE
remove download_url (unsupported since PEP 470)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.pyc
+__pycache__
 .coverage
 htmlcov
+
+# distribution
+dist
+*.egg-info

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,10 @@ setup(
     author='Florent Lebreton',
     author_email='florent.lebreton@makina-corpus.com',
     url='https://github.com/fle/django-multi-email-field',
-    download_url="https://github.com/fle/django-multi-email-field/tarball/0.5",
     description="Provides a model field and a form field to manage list of e-mails",
     long_description=open(os.path.join(here, 'README.rst')).read() + '\n\n' +
         open(os.path.join(here, 'CHANGES')).read(),
-    license='LPGL, see LICENSE file.',
+    license='LGPL, see LICENSE file.',
     install_requires=['Django'],
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
PyPI used to be able to scrape download_url and pip would also make use of it as an "external repository". This has been unsupported since PEP 470 was implemented (~2015-09).
As of now, releases to pypi have to be uploaded directly (e.g. `python setup.py sdist upload`). This PR just makes this more explicit.
As can be seen in [pypi's simple index](https://pypi.python.org/simple/django-multi-email-field/), newer releases haven't been scraped, causing #5 .
Additionally, the `--allow-external` flag also has been deprecated (actually disabled), so it's impossible to work around this.