### PR TITLE
compat dj 2.1: forward renderer in Widget.render()

### DIFF
--- a/multi_email_field/widgets.py
+++ b/multi_email_field/widgets.py
@@ -21,6 +21,6 @@ class MultiEmailWidget(Textarea):
             return "\n".join(value)
         raise ValidationError('Invalid format.')
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, **kwargs):
         value = self.prep_value(value)
-        return super(MultiEmailWidget, self).render(name, value, attrs)
+        return super(MultiEmailWidget, self).render(name, value, **kwargs)

--- a/multi_email_field/widgets.py
+++ b/multi_email_field/widgets.py
@@ -21,6 +21,6 @@ class MultiEmailWidget(Textarea):
             return "\n".join(value)
         raise ValidationError('Invalid format.')
 
-    def render(self, name, value, **kwargs):
+    def render(self, name, value, attrs=None, **kwargs):
         value = self.prep_value(value)
-        return super(MultiEmailWidget, self).render(name, value, **kwargs)
+        return super(MultiEmailWidget, self).render(name, value, attrs, **kwargs)


### PR DESCRIPTION
Support for Widget.render() methods without the renderer argument is removed.

https://docs.djangoproject.com/en/2.1/releases/2.1/#features-removed-in-2-1