### PR TITLE
Fix RemovedInDjango40 error

### DIFF
--- a/multi_email_field/forms.py
+++ b/multi_email_field/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.core.validators import validate_email
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from multi_email_field.widgets import MultiEmailWidget
 


### PR DESCRIPTION
This package will raise this error `ImportError: cannot import name 'ugettext_lazy' from 'django.utils.translation'` when run with Django40. I have resolved this issue in this PR.